### PR TITLE
(feat): profile_page, login_widget, registration_widget

### DIFF
--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -67,16 +67,18 @@ class _ProfilePageState extends State<ProfilePage> {
       source: ImageSource.gallery,
     );
 
-    if (pickedFile != null) {
+    if (pickedFile != null && mounted) {
       File imageFile = File(pickedFile.path);
       final userProvider = Provider.of<UserProvider>(context, listen: false);
       final success = await userProvider.uploadProfileImage(imageFile);
 
-      if (mounted && success) {
+      if (!mounted) return;
+
+      if (success) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Imatge de perfil actualitzada!')),
         );
-      } else if (mounted && !success) {
+      } else {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Error al pujar la imatge.')),
         );
@@ -87,6 +89,8 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _saveProfileChanges() async {
+    if (!mounted) return;
+    
     final userProvider = Provider.of<UserProvider>(context, listen: false);
 
     final name = _nameController.text.trim();
@@ -107,11 +111,13 @@ class _ProfilePageState extends State<ProfilePage> {
       lastname: lastname,
     );
 
-    if (mounted && success) {
+    if (!mounted) return;
+
+    if (success) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Perfil desat correctament!')),
       );
-    } else if (mounted && !success) {
+    } else {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Error al desar el perfil.')),
       );

--- a/lib/widgets/login_widget.dart
+++ b/lib/widgets/login_widget.dart
@@ -17,12 +17,21 @@ class _LoginPageState extends State<LoginPage> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  
+  void _showSnackBarSafe(String message, {Color? backgroundColor}) {
+    if (mounted) {
+      ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: backgroundColor,
+        ),
+      );
+    }
+  }
 
   Future<void> _forgotPassword() async {
     if (_emailController.text.trim().isEmpty) {
-      ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
-        const SnackBar(content: Text('Por favor, introduce un email')),
-      );
+      _showSnackBarSafe('Por favor, introduce un email');
       return;
     }
     //coverage:ignore-start
@@ -30,18 +39,12 @@ class _LoginPageState extends State<LoginPage> {
       await FirebaseAuth.instance.sendPasswordResetEmail(
         email: _emailController.text,
       );
-      ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Se ha enviado un email para restablecer la contraseña',
-          ),
-        ),
+      _showSnackBarSafe(
+        'Se ha enviado un email para restablecer la contraseña',
       );
     } on FirebaseAuthException catch (e) {
       debugPrint('Failed to send password reset email: ${e.message}');
-      ScaffoldMessenger.of(
-        widget.homePageContext,
-      ).showSnackBar(SnackBar(content: Text('Error: ${e.message}')));
+      _showSnackBarSafe('Error: ${e.message}');
     }
     //coverage:ignore-end
   }
@@ -87,6 +90,8 @@ class _LoginPageState extends State<LoginPage> {
                           // coverage:ignore-start
                           onPressed: () async {
                             if (_formKey.currentState!.validate()) {
+                              final navigator = Navigator.of(context);
+                              final scaffoldMessenger = ScaffoldMessenger.of(context);
                               try {
                                 await FirebaseAuth.instance
                                     .signInWithEmailAndPassword(
@@ -96,17 +101,19 @@ class _LoginPageState extends State<LoginPage> {
                                 debugPrint(
                                   'User logged in: ${_emailController.text}',
                                 );
-                                if (mounted) Navigator.of(context).pop();
+                                if (mounted) navigator.pop();
                               } on FirebaseAuthException catch (e) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  // Usamos el context del Dialog
-                                  SnackBar(
-                                    content: Text(
-                                      'Error al iniciar sesión: ${e.message}',
+                                if (mounted) {
+                                  scaffoldMessenger.showSnackBar(
+                                    // Usamos el context del Dialog
+                                    SnackBar(
+                                      content: Text(
+                                        'Error al iniciar sesión: ${e.message}',
+                                      ),
+                                      backgroundColor: Colors.red,
                                     ),
-                                    backgroundColor: Colors.red,
-                                  ),
-                                );
+                                  );
+                                }
                               }
                               // coverage:ignore-end
                             }

--- a/lib/widgets/registration_widget.dart
+++ b/lib/widgets/registration_widget.dart
@@ -21,9 +21,21 @@ class _RegistrationPageState extends State<RegistrationPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
+  
+  void _showSnackBarSafe(String message, {Color? backgroundColor}) {
+    if (mounted) {
+      ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: backgroundColor,
+        ),
+      );
+    }
+  }
 
   Future<void> _register() async {
     if (_formKey.currentState!.validate()) {
+      final navigator = Navigator.of(context);
       // coverage:ignore-start
       try {
         UserCredential userCredential = await FirebaseAuth.instance
@@ -34,7 +46,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
         debugPrint('User ${userCredential.user!.email} registered');
 
         final User? user = userCredential.user;
-        if (user != null) {
+        if (user != null && mounted) {
           await user.sendEmailVerification();
           debugPrint('Email verification sent to ${user.email}');
 
@@ -51,29 +63,26 @@ class _RegistrationPageState extends State<RegistrationPage> {
               .doc(user.uid)
               .set(userModel.toFirestore());
 
-          ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
-            const SnackBar(
-              content: Text('Usuario registrado correctamente'),
-              backgroundColor: Colors.green,
-            ),
+          _showSnackBarSafe(
+            'Usuario registrado correctamente',
+            backgroundColor: Colors.green,
           );
-          if (mounted) Navigator.of(context).pop();
+          
+          if (mounted) {
+            navigator.pop();
+          }
         }
       } on FirebaseAuthException catch (e) {
         debugPrint('Failed with error code: ${e.message}');
-        ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
-          SnackBar(
-            content: Text('Error: ${e.message}'),
-            backgroundColor: Colors.red,
-          ),
+        _showSnackBarSafe(
+          'Error: ${e.message}',
+          backgroundColor: Colors.red,
         );
       } catch (e) {
         debugPrint('Error desconocido al registrar o guardar datos: $e');
-        ScaffoldMessenger.of(widget.homePageContext).showSnackBar(
-          const SnackBar(
-            content: Text('Error desconocido al registrar o guardar datos'),
-            backgroundColor: Colors.red,
-          ),
+        _showSnackBarSafe(
+          'Error desconocido al registrar o guardar datos',
+          backgroundColor: Colors.red,
         );
       }
       // coverage:ignore-end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -580,26 +580,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -881,10 +881,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
### Resumen del commit

**Fecha:** 19 de agosto de 2025  
**Autor:** Pablo Cortés

#### Descripción principal
Mejora la gestión de estado en los widgets de perfil, inicio de sesión y registro para evitar errores cuando el widget ya no está montado (mounted).

---

#### Cambios destacados

- **profile_page.dart**
  - Se añade la comprobación de `mounted` antes de actualizar el estado o mostrar SnackBars tras operaciones asíncronas (como subir imagen o guardar cambios).
  - Se reorganiza la lógica para evitar acciones si el widget fue desmontado.

- **login_widget.dart**
  - Se crea el método privado `_showSnackBarSafe` para mostrar SnackBars solo si el widget está montado.
  - Se usa este método en el flujo de recuperación de contraseña y en el manejo de errores de inicio de sesión.
  - Se mejora la gestión de navegación y mensajes de error para evitar llamadas a contextos no válidos.

- **registration_widget.dart**
  - Se implementa `_showSnackBarSafe` para mostrar mensajes de éxito o error solo si el widget está montado.
  - Se asegura que la navegación y los mensajes tras el registro solo se ejecuten si el widget sigue montado.

- **pubspec.lock**
  - Se actualizan varias dependencias relacionadas con pruebas y utilidades (por ejemplo, leak_tracker, test_api, vector_math).

---

#### Impacto
- Se previenen errores de estado y excepciones relacionadas con el uso de contextos de widgets desmontados.
- Mejor experiencia de usuario y mayor robustez en los flujos de perfil, login y registro.
- Código más seguro y mantenible en operaciones asíncronas.