### PR TITLE
fix: Actualizar configuración de Gradle, permisos de Android y mejorar mensajes de notificación

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,13 +11,13 @@ android {
     ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -5,5 +5,6 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <application
         android:label="HCC App"
         android:name="${applicationName}"

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
     id("com.google.gms.google-services") version("4.4.2") apply false
-    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,13 +13,9 @@ import 'package:hcc_app/firebase_options.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  debugPrint('App initialization started'); // Mensaje de depuración
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  debugPrint('Firebase initialized successfully'); // Mensaje de depuración
   await NotificationService.init();
-  debugPrint(
-    'Notification service initialized successfully',
-  ); // Mensaje de depuración
+  await NotificationService.requestPermissions();
   runApp(
     MultiProvider(
       providers: [

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -30,13 +30,10 @@ class NotificationService {
 
   // 1. Inicializa el plugin de notificaciones
   static Future<void> init() async {
-    // Inicializar zona horaria para notificaciones programadas
     tz.initializeTimeZones();
 
     const AndroidInitializationSettings initializationSettingsAndroid =
-        AndroidInitializationSettings(
-          'ic_notification', // Corregido el nombre del icono
-        );
+        AndroidInitializationSettings('ic_notification');
 
     const DarwinInitializationSettings initializationSettingsIOS =
         DarwinInitializationSettings();
@@ -52,19 +49,15 @@ class NotificationService {
       onDidReceiveNotificationResponse: (NotificationResponse response) {
         if (response.payload != null) {
           debugPrint('Notificación recibida con payload: ${response.payload}');
-          // Manejar la carga útil de la notificación si es necesario
         }
-        // Manejar la respuesta a la notificación si es necesario
       },
     );
   }
 
-  // 2. Programa la notificación para un evento
   static Future<void> scheduleEventNotification(
     Event event, {
     Duration reminderTime = const Duration(hours: 1),
   }) async {
-    // Convertir el ID del evento a un entero para el ID de la notificación
     final int notificationId = event.id.hashCode;
 
     final tz.TZDateTime scheduledTime = tz.TZDateTime.from(
@@ -76,7 +69,7 @@ class NotificationService {
         AndroidNotificationDetails(
           'event_channel_id',
           'Event Notifications',
-          channelDescription: 'Notificaciones para eventos agendados.',
+          channelDescription: 'Notificaciones para eventos HCC.',
           importance: Importance.max,
           priority: Priority.high,
         );
@@ -92,7 +85,7 @@ class NotificationService {
       await _flutterLocalNotificationsPlugin.zonedSchedule(
         notificationId,
         event.title,
-        'Tu evento está a punto de empezar!',
+        'Evento de HCC está a punto de empezar!',
         scheduledTime,
         platformDetails,
         androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
@@ -106,7 +99,7 @@ class NotificationService {
         await _flutterLocalNotificationsPlugin.zonedSchedule(
           notificationId,
           event.title,
-          'Tu evento está a punto de empezar! (Recordatorio no exacto)',
+          'Evento de HCC está a punto de empezar! (Recordatorio no exacto)',
           scheduledTime,
           platformDetails,
           androidScheduleMode: AndroidScheduleMode.inexact,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: hcc_app
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -64,7 +64,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -72,7 +71,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
-  - assets/images/
+    - assets/images/
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
Este commit incluye varias actualizaciones importantes en la configuración y el funcionamiento de las notificaciones de la aplicación:

- Actualización de Java de versión 1.8 a 11 en el archivo build.gradle.kts
- Actualización de Kotlin de versión 2.0.0 a 2.1.0
- Añadido y reorganizado el permiso `USE_EXACT_ALARM` en los manifiestos de Android

- Añadida llamada a `NotificationService.requestPermissions()` en el archivo main.dart
- Eliminados mensajes de depuración innecesarios en la inicialización
- Mejorados los textos de las notificaciones, cambiando "Tu evento" por "Evento de HCC"
- Actualizada la descripción del canal de notificaciones a "Notificaciones para eventos HCC"

- Mejoras de formato en pubspec.yaml

Estos cambios mejoran la compatibilidad con versiones recientes de Android y refinan la experiencia de notificaciones para los usuarios.