### PR TITLE
feat: Corregir la referencia del mensaje de commit en la actualización del cuerpo de la PR

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -120,7 +120,7 @@ jobs:
           COMMIT_MSG_ENV: ${{ steps.bump-type.outputs.commit_message }}
         run: |
           DATE=$(date +%Y-%m-%d)
-          RAW_COMMIT_MSG="COMMIT_MSG_ENV"
+          RAW_COMMIT_MSG="$COMMIT_MSG_ENV"
           # 1. Procesar el mensaje del commit: Convertir '\n' literal en saltos de línea reales
           #    Usamos printf '%b' que interpreta las secuencias de escape como \n, \t, etc.
           COMMIT_MSG=$(printf '%b' "$RAW_COMMIT_MSG")
@@ -158,6 +158,7 @@ jobs:
       - name: Create Pull Request for Version Bump
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY_ENV : ${{ steps.bump-type.outputs.commit_message }}
         run: |
           # Definir variables útiles
           NEW_VERSION_FULL="${{ steps.bump-version.outputs.new_version }}+${{ steps.bump-version.outputs.new_build }}"
@@ -165,8 +166,7 @@ jobs:
           COMMIT_MSG="Bump version to ${NEW_VERSION_FULL}" # Mensaje de commit
           PR_TITLE="${COMMIT_MSG}" # Título para la PR
           # Cuerpo para la PR (usaremos el mensaje procesado del commit original)
-          RAW_COMMIT_MSG="${{ steps.bump-type.outputs.commit_message }}"
-          PR_BODY=$(printf '%b' "$RAW_COMMIT_MSG")
+          PR_BODY=$(printf '%b' "$PR_BODY_ENV")
           echo "Configurando Git..."
           git config --local user.email "action@github.com"
           # Puedes poner un nombre más descriptivo si quieres


### PR DESCRIPTION
El commit ee21ee7cb2d2e62e44a4d426851e1ade1b767f2e corrige la referencia al mensaje de commit en el workflow de GitHub Actions (.github/workflows/version-bump.yml). Específicamente:

- En el paso "Update CHANGELOG.md", la variable RAW_COMMIT_MSG ahora se asigna correctamente usando `$COMMIT_MSG_ENV` en vez de la cadena literal `"COMMIT_MSG_ENV"`.
- En el paso "Create Pull Request for Version Bump", el cuerpo de la PR (`PR_BODY`) ahora utiliza la variable de entorno `PR_BODY_ENV` procesada con `printf '%b'`, asegurando que el mensaje del commit se incluya correctamente en la PR.

Esto soluciona un error donde el mensaje de commit no se mostraba correctamente en el changelog ni en el cuerpo de la pull request.