### PR TITLE
feat(models): Add Product and SaleOrder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "cmake.sourceDirectory": "/home/pablo-cortes/FlutterProjects/hcc_app/linux",
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/lib/models/product_model.dart
+++ b/lib/models/product_model.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 HCC. All rights reserved.
+// Use of this source code is governed by an GNU GENERAL PUBLIC LICENSE
+// license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Product {
+  final String id;
+  final String name;
+  final String code;
+  final double price;
+  final String image;
+  final Timestamp createdAt;
+
+  Product({
+    required this.id,
+    required this.name,
+    required this.code,
+    required this.price,
+    required this.image,
+    required this.createdAt,
+  });
+
+  factory Product.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  ) {
+    final data = snapshot.data();
+    return Product(
+      id: snapshot.id,
+      name: data?['name'] ?? '',
+      code: data?['code'] ?? '',
+      price: (data?['price'] as num?)?.toDouble() ?? 0.0,
+      image: data?['image'] ?? '',
+      createdAt: data?['created_at'] as Timestamp? ?? Timestamp.now(),
+    );
+  }
+
+  factory Product.fromMap(Map<String, dynamic> data) {
+    return Product(
+      id: data['id'] ?? '',
+      name: data['name'] ?? '',
+      code: data['code'] ?? '',
+      price: (data['price'] as num?)?.toDouble() ?? 0.0,
+      image: data['image'] ?? '',
+      createdAt: data['created_at'] as Timestamp? ?? Timestamp.now(),
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'name': name,
+      'code': code,
+      'price': price,
+      'image': image,
+      'created_at': FieldValue.serverTimestamp(),
+    };
+  }
+}

--- a/lib/models/sale_order_model.dart
+++ b/lib/models/sale_order_model.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 HCC. All rights reserved.
+// Use of this source code is governed by an GNU GENERAL PUBLIC LICENSE
+// license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:hcc_app/models/user_model.dart';
+import 'package:hcc_app/models/product_model.dart';
+
+class SaleOrder {
+  final String id;
+  final String name;
+  final DateTime date;
+  final String status;
+  final UserModel partner;
+  final String creatorUid;
+  final double? amount;
+  final String? currency;
+  final List<SaleOrderLine> saleOrderLines;
+  final String? paymentState;
+  final Timestamp createdAt;
+
+  SaleOrder({
+    required this.id,
+    required this.name,
+    required this.date,
+    required this.status,
+    required this.partner,
+    required this.creatorUid,
+    this.amount,
+    this.currency,
+    required this.saleOrderLines,
+    this.paymentState,
+    required this.createdAt,
+  });
+
+  factory SaleOrder.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  ) {
+    final data = snapshot.data();
+
+    final partnerData = data?['partner'] as Map<String, dynamic>?;
+
+    return SaleOrder(
+      id: snapshot.id,
+      name: data?['name'] ?? '',
+      date: (data?['date'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      status: data?['status'] ?? '',
+      partner:
+          partnerData != null ? UserModel.fromMap(partnerData) : UserModel(),
+      creatorUid: data?['creatorUid'] ?? '',
+      amount: (data?['amount'] as num?)?.toDouble(),
+      currency: data?['currency'],
+      saleOrderLines:
+          (data?['saleOrderLines'] as List<dynamic>?)
+              ?.map((e) => SaleOrderLine.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      paymentState: data?['paymentState'],
+      createdAt: data?['created_at'] as Timestamp? ?? Timestamp.now(),
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'name': name,
+      'date': date,
+      'status': status,
+      'partner': partner.toFirestore(),
+      'creatorUid': creatorUid,
+      'amount': amount,
+      'currency': currency,
+      'saleOrderLines': saleOrderLines.map((e) => e.toFirestore()).toList(),
+      'paymentState': paymentState,
+      'created_at': FieldValue.serverTimestamp(),
+    };
+  }
+}
+
+class SaleOrderLine {
+  final String id;
+  final Product product;
+  final String name;
+  final String productCode;
+  final double price;
+  final int quantity;
+  final double total;
+
+  SaleOrderLine({
+    required this.id,
+    required this.product,
+    required this.name,
+    required this.productCode,
+    required this.price,
+    required this.quantity,
+    required this.total,
+  });
+
+  factory SaleOrderLine.fromMap(Map<String, dynamic> data) {
+    return SaleOrderLine(
+      id: data['id'] ?? '',
+      product: Product.fromMap(data['product'] as Map<String, dynamic>),
+      name: data['name'] ?? '',
+      productCode: data['productCode'] ?? '',
+      price: (data['price'] as num?)?.toDouble() ?? 0.0,
+      quantity: (data['quantity'] as num?)?.toInt() ?? 0,
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'id': id,
+      'product': product.toFirestore(),
+      'name': name,
+      'productCode': productCode,
+      'price': price,
+      'quantity': quantity,
+      'total': total,
+    };
+  }
+}

--- a/test/models/model_test.dart
+++ b/test/models/model_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:hcc_app/models/product_model.dart';
+import 'package:hcc_app/models/sale_order_model.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+void main() {
+  group('Product Model', () {
+    test('should correctly serialize and deserialize', () async {
+      final instance = FakeFirebaseFirestore();
+      final data = {
+        'name': 'Test Product',
+        'code': 'TP001',
+        'price': 100.0,
+        'image': 'http://image.com',
+        'created_at': Timestamp.now(),
+      };
+      final ref = await instance.collection('products').add(data);
+      final snapshot = await ref.get();
+
+      final product = Product.fromFirestore(snapshot, null);
+
+      expect(product.name, 'Test Product');
+      expect(product.price, 100.0);
+      expect(product.code, 'TP001');
+
+      final map = product.toFirestore();
+      expect(map['name'], 'Test Product');
+      expect(map['price'], 100.0);
+    });
+
+    test('should handle nulls and type conversion', () async {
+      final instance = FakeFirebaseFirestore();
+      final data = {
+        'price': 100, // int
+      };
+      final ref = await instance.collection('products').add(data);
+      final snapshot = await ref.get();
+
+      final product = Product.fromFirestore(snapshot, null);
+      expect(product.price, 100.0);
+      expect(product.name, '');
+      expect(product.code, '');
+    });
+
+    test('fromMap should work correctly', () {
+      final data = {'id': '123', 'name': 'Map Product', 'price': 50};
+      final product = Product.fromMap(data);
+      expect(product.id, '123');
+      expect(product.name, 'Map Product');
+      expect(product.price, 50.0);
+    });
+  });
+
+  group('SaleOrder Model', () {
+    test(
+      'should correctly serialize and deserialize with nested objects',
+      () async {
+        final instance = FakeFirebaseFirestore();
+        final partnerData = {
+          'id': 'user1',
+          'name': 'John',
+          'email': 'john@test.com',
+          'role': 'admin',
+        };
+        final productData = {'id': 'prod1', 'name': 'Prod 1', 'price': 50.0};
+        final lineData = {
+          'id': 'line1',
+          'product': productData,
+          'name': 'Line 1',
+          'productCode': 'P1',
+          'price': 50.0,
+          'quantity': 2,
+          'total': 100.0,
+        };
+
+        final orderData = {
+          'name': 'Order 1',
+          'date': Timestamp.now(),
+          'status': 'draft',
+          'partner': partnerData,
+          'saleOrderLines': [lineData],
+          'amount': 100.0,
+          'created_at': Timestamp.now(),
+        };
+
+        final ref = await instance.collection('orders').add(orderData);
+        final snapshot = await ref.get();
+
+        final order = SaleOrder.fromFirestore(snapshot, null);
+
+        expect(order.name, 'Order 1');
+        expect(order.partner.name, 'John');
+        expect(order.saleOrderLines.length, 1);
+        expect(order.saleOrderLines.first.product.name, 'Prod 1');
+        expect(order.saleOrderLines.first.total, 100.0);
+
+        final map = order.toFirestore();
+        expect(map['partner']['name'], 'John');
+        expect(map['saleOrderLines'][0]['product']['name'], 'Prod 1');
+      },
+    );
+
+    test('should handle nulls and missing nested data', () async {
+      final instance = FakeFirebaseFirestore();
+      final data = {'name': 'Empty Order'};
+      final ref = await instance.collection('orders').add(data);
+      final snapshot = await ref.get();
+
+      final order = SaleOrder.fromFirestore(snapshot, null);
+      expect(order.name, 'Empty Order');
+      expect(order.saleOrderLines, isEmpty);
+      expect(order.partner.name, isNull); // UserModel defaults
+    });
+  });
+}


### PR DESCRIPTION
**Resumen General:** 
Este commit mejora la robustez de los modelos de datos (Product   y   SaleOrder ) para evitar errores comunes en tiempo de ejecución (como tipos de datos incorrectos o valores nulos) y añade pruebas unitarias para verificar su funcionamiento.

**Detalles por Archivo:**

1.  lib/models/product\_model.dart:
    
    *   (data?\['price'\] as num?)?.toDouble()) para asegurar que si Firestore devuelve un int, la app no falle al esperar un double.
        
    *   ?? '' o ?? 0.0) para evitar errores si faltan campos en la base de datos.
        
    *   factory Product.fromMap(...) para facilitar la creación de productos desde mapas, útil para objetos anidados.
        
2.  lib/models/sale\_order\_model.dart:
    
    *   **Objetos Anidados**: Se corrigió la forma en que se leen y escriben objetos complejos dentro de una orden de venta:
        
        *   : Ahora se convierte correctamente de un mapa a un objeto UserModel.
            
        *   : Ahora se convierte correctamente la lista de mapas a una lista de objetos SaleOrderLine.
            
    *   : Se añadió fromMap para permitir su deserialización dentro de la lista de líneas de la orden.
        
3.  test/models/model\_test.dart (Nuevo Archivo):
    
    *   Se crearon pruebas unitarias para verificar que:
        
        *   Los modelos se crean correctamente desde Firestore.
            
        *   Los modelos se convierten correctamente a mapas para guardar en Firestore.
            
        *   Los valores nulos y tipos numéricos mixtos se manejan sin errores.
            
        *   Los objetos anidados se procesan correctamente.